### PR TITLE
feat: enable setting and storing a custom url for XUD Docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "axios": "^0.20.0",
     "cross-env": "^7.0.2",
     "electron-is-dev": "^1.2.0",
+    "mobx": "^5.15.7",
+    "mobx-react": "^6.3.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,15 @@
 import CssBaseline from "@material-ui/core/CssBaseline";
 import { createMuiTheme } from "@material-ui/core/styles";
 import { ThemeProvider } from "@material-ui/styles";
+import { Provider } from "mobx-react";
 import React, { ReactElement } from "react";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { XUD_DOCKER_LOCAL_MAINNET_URL } from "./constants";
 import Dashboard from "./dashboard/Dashboard";
 import { Path } from "./router/Path";
 import ConnectToRemote from "./setup/ConnectToRemote";
 import DockerNotDetected from "./setup/DockerNotDetected";
+import { useSettingsStore } from "./stores/settingsStore";
 
 const darkTheme = createMuiTheme({
   palette: {
@@ -14,23 +17,29 @@ const darkTheme = createMuiTheme({
   },
 });
 
+const settingsStore = useSettingsStore({
+  xudDockerUrl: XUD_DOCKER_LOCAL_MAINNET_URL,
+});
+
 function App(): ReactElement {
   return (
     <ThemeProvider theme={darkTheme}>
       <CssBaseline />
-      <Router>
-        <Switch>
-          <Route path={Path.CONNECT_TO_REMOTE}>
-            <ConnectToRemote />
-          </Route>
-          <Route path={Path.DASHBOARD}>
-            <Dashboard />
-          </Route>
-          <Route path={Path.HOME}>
-            <DockerNotDetected />
-          </Route>
-        </Switch>
-      </Router>
+      <Provider settingsStore={settingsStore}>
+        <Router>
+          <Switch>
+            <Route path={Path.CONNECT_TO_REMOTE}>
+              <ConnectToRemote />
+            </Route>
+            <Route path={Path.DASHBOARD}>
+              <Dashboard />
+            </Route>
+            <Route path={Path.HOME}>
+              <DockerNotDetected />
+            </Route>
+          </Switch>
+        </Router>
+      </Provider>
     </ThemeProvider>
   );
 }

--- a/src/api.tsx
+++ b/src/api.tsx
@@ -2,10 +2,10 @@ import axios from "axios";
 import { from, Observable } from "rxjs";
 import { pluck } from "rxjs/operators";
 
-const url = "http://localhost:8080/api/v1/xud";
+const path = "api/v1/xud";
 
 export default {
-  getinfo$(): Observable<any> {
-    return from(axios.get(`${url}/getinfo`)).pipe(pluck("data"));
+  getinfo$(url: string): Observable<any> {
+    return from(axios.get(`${url}/${path}/getinfo`)).pipe(pluck("data"));
   },
 };

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,0 +1,4 @@
+export const XUD_DOCKER_DOCS_URL =
+  "https://docs.exchangeunion.com/start-earning/market-maker-guide";
+
+export const XUD_DOCKER_LOCAL_MAINNET_URL = "http://localhost:8889";

--- a/src/dashboard/Overview.tsx
+++ b/src/dashboard/Overview.tsx
@@ -1,12 +1,17 @@
+import { inject, observer } from "mobx-react";
 import React, { Component, ReactElement } from "react";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 import { PartialObserver, Subscription, timer } from "rxjs";
 import { mergeMap } from "rxjs/operators";
 import api from "../api";
 import { Path } from "../router/Path";
+import { SETTINGS_STORE } from "../stores/settingsStore";
+import { WithStores } from "../stores/WithStores";
 
-type PropsType = RouteComponentProps<{ param1: string }>;
+type PropsType = RouteComponentProps<{ param1: string }> & WithStores;
 
+@inject(SETTINGS_STORE)
+@observer
 class Overview extends Component<PropsType> {
   private subscriptions: Subscription[] = [];
 
@@ -18,7 +23,9 @@ class Overview extends Component<PropsType> {
   componentDidMount() {
     this.subscriptions.push(
       timer(0, 5000)
-        .pipe(mergeMap(api.getinfo$))
+        .pipe(
+          mergeMap(() => api.getinfo$(this.props.settingsStore!.xudDockerUrl))
+        )
         .subscribe(this.handleGetinfo())
     );
   }

--- a/src/dashboard/menu/MenuItemProps.tsx
+++ b/src/dashboard/menu/MenuItemProps.tsx
@@ -4,5 +4,5 @@ import { Path } from "../../router/Path";
 export type MenuItemProps = {
   path: Path;
   text: string;
-  component: ComponentClass | (() => ReactElement);
+  component: ComponentClass<any> | (() => ReactElement);
 };

--- a/src/setup/ConnectToRemote.tsx
+++ b/src/setup/ConnectToRemote.tsx
@@ -4,70 +4,103 @@ import Grid from "@material-ui/core/Grid";
 import TextField from "@material-ui/core/TextField";
 import Typography from "@material-ui/core/Typography";
 import { History } from "history";
-import React, { ReactElement, useState } from "react";
+import { inject, observer } from "mobx-react";
+import React, { useState } from "react";
 import { useHistory } from "react-router-dom";
 import api from "../api";
 import RowsContainer from "../common/RowsContainer";
 import { Path } from "../router/Path";
+import { SETTINGS_STORE } from "../stores/settingsStore";
+import { WithStores } from "../stores/WithStores";
 
-function ConnectToRemote(): ReactElement {
-  const history = useHistory();
-  const [connectionFailed, setConnectionFailed] = useState(false);
-  const [connecting, setConnecting] = useState(false);
+type ConnectToRemoteProps = WithStores;
 
-  return (
-    <RowsContainer>
-      <Grid container item alignItems="center" justify="center">
-        <Typography variant="h4" component="h4">
-          Connect to a remote XUD environment
-        </Typography>
-      </Grid>
-      <form noValidate autoComplete="off">
-        <Grid container item alignItems="center" direction="column" spacing={4}>
-          <Grid item container justify="center">
-            <TextField id="ip-port" label="IP:Port" variant="outlined" />
-          </Grid>
-          {connectionFailed && (
-            <Grid item container justify="center">
-              <Typography variant="body2" component="p" color="secondary">
-                Error: Connection failed
-              </Typography>
-            </Grid>
-          )}
-          <Grid item container justify="center">
-            <Button
-              variant="contained"
-              color="primary"
-              disabled={connecting}
-              onClick={() =>
-                handleConnectClick(setConnectionFailed, setConnecting, history)
-              }
-            >
-              {connectionFailed ? "Retry" : "Connect"}
-              {connecting && (
-                <>
-                  &nbsp;
-                  <CircularProgress color="inherit" size="15px" />
-                </>
-              )}
-            </Button>
-          </Grid>
+const ConnectToRemote = inject(SETTINGS_STORE)(
+  observer(({ settingsStore }: ConnectToRemoteProps) => {
+    const history = useHistory();
+    const [ipAndPort, setIpAndPort] = useState("");
+    const [connectionFailed, setConnectionFailed] = useState(false);
+    const [connecting, setConnecting] = useState(false);
+
+    return (
+      <RowsContainer>
+        <Grid container item alignItems="center" justify="center">
+          <Typography variant="h4" component="h4">
+            Connect to a remote XUD environment
+          </Typography>
         </Grid>
-      </form>
-    </RowsContainer>
-  );
-}
+        <form noValidate autoComplete="off">
+          <Grid
+            container
+            item
+            alignItems="center"
+            direction="column"
+            spacing={4}
+          >
+            <Grid item container justify="center">
+              <TextField
+                id="ip-port"
+                label="IP:Port"
+                variant="outlined"
+                value={ipAndPort}
+                onChange={(e) => setIpAndPort(e.target.value)}
+              />
+            </Grid>
+            {connectionFailed && (
+              <Grid item container justify="center">
+                <Typography variant="body2" component="p" color="secondary">
+                  Error: Connection failed
+                </Typography>
+              </Grid>
+            )}
+            <Grid item container justify="center">
+              <Button
+                type="submit"
+                variant="contained"
+                color="primary"
+                disabled={connecting}
+                onClick={() =>
+                  handleConnectClick(
+                    setConnectionFailed,
+                    setConnecting,
+                    history,
+                    ipAndPort,
+                    settingsStore!.setXudDockerUrl
+                  )
+                }
+              >
+                {connectionFailed ? "Retry" : "Connect"}
+                {connecting && (
+                  <>
+                    &nbsp;
+                    <CircularProgress color="inherit" size="15px" />
+                  </>
+                )}
+              </Button>
+            </Grid>
+          </Grid>
+        </form>
+      </RowsContainer>
+    );
+  })
+);
 
 const handleConnectClick = (
   setConnectionFailed: (value: boolean) => void,
   setConnecting: (value: boolean) => void,
-  history: History
+  history: History,
+  xudDockerUrl: string,
+  setXudDockerUrl: (ip: string) => void
 ): void => {
+  const address = xudDockerUrl.startsWith("http")
+    ? xudDockerUrl
+    : `http://${xudDockerUrl}`;
   setConnectionFailed(false);
   setConnecting(true);
-  api.getinfo$().subscribe({
+  api.getinfo$(address).subscribe({
     next: () => {
       setConnecting(false);
+      setXudDockerUrl(address);
       history.push(Path.DASHBOARD);
     },
     error: () => {

--- a/src/setup/DockerNotDetected.tsx
+++ b/src/setup/DockerNotDetected.tsx
@@ -3,48 +3,55 @@ import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 import ArrowForwardIcon from "@material-ui/icons/ArrowForward";
 import ReportProblemOutlinedIcon from "@material-ui/icons/ReportProblemOutlined";
-import React, { ReactElement, useState } from "react";
+import { inject, observer } from "mobx-react";
+import React, { useState } from "react";
 import { Link as RouterLink, useHistory } from "react-router-dom";
 import api from "../api";
 import RowsContainer from "../common/RowsContainer";
 import { Path } from "../router/Path";
+import { SETTINGS_STORE } from "../stores/settingsStore";
+import { WithStores } from "../stores/WithStores";
 import LinkToSetupGuide from "./LinkToSetupGuide";
 
-function DockerNotDetected(): ReactElement {
-  const history = useHistory();
-  const [connectionFailed, setConnectionFailed] = useState(false);
+type DockerNotDetectedProps = WithStores;
 
-  api.getinfo$().subscribe({
-    next: () => history.push(Path.DASHBOARD),
-    error: () => setConnectionFailed(true),
-  });
+const DockerNotDetected = inject(SETTINGS_STORE)(
+  observer(({ settingsStore }: DockerNotDetectedProps) => {
+    const history = useHistory();
+    const [connectionFailed, setConnectionFailed] = useState(false);
 
-  return (
-    <RowsContainer>
-      <Grid container item alignItems="center" justify="center">
-        <ReportProblemOutlinedIcon fontSize="large" />
-        &nbsp;
-        <Typography variant="h4" component="h1">
-          {connectionFailed
-            ? "XUD Docker not detected"
-            : "Connecting to XUD Docker"}
-        </Typography>
-      </Grid>
-      <Grid container item alignItems="center" justify="center">
-        <Button
-          component={RouterLink}
-          to={Path.CONNECT_TO_REMOTE}
-          variant="outlined"
-          endIcon={<ArrowForwardIcon />}
-        >
-          Connect remote XUD Docker
-        </Button>
-      </Grid>
-      <Grid container item alignItems="center">
-        <LinkToSetupGuide />
-      </Grid>
-    </RowsContainer>
-  );
-}
+    api.getinfo$(settingsStore!.xudDockerUrl).subscribe({
+      next: () => history.push(Path.DASHBOARD),
+      error: () => setConnectionFailed(true),
+    });
+
+    return (
+      <RowsContainer>
+        <Grid container item alignItems="center" justify="center">
+          <ReportProblemOutlinedIcon fontSize="large" />
+          &nbsp;
+          <Typography variant="h4" component="h1">
+            {connectionFailed
+              ? "XUD Docker not detected"
+              : "Connecting to XUD Docker"}
+          </Typography>
+        </Grid>
+        <Grid container item alignItems="center" justify="center">
+          <Button
+            component={RouterLink}
+            to={Path.CONNECT_TO_REMOTE}
+            variant="outlined"
+            endIcon={<ArrowForwardIcon />}
+          >
+            Connect remote XUD Docker
+          </Button>
+        </Grid>
+        <Grid container item alignItems="center">
+          <LinkToSetupGuide />
+        </Grid>
+      </RowsContainer>
+    );
+  })
+);
 
 export default DockerNotDetected;

--- a/src/setup/LinkToSetupGuide.tsx
+++ b/src/setup/LinkToSetupGuide.tsx
@@ -1,9 +1,7 @@
 import Link from "@material-ui/core/Link";
 import OpenInNewIcon from "@material-ui/icons/OpenInNew";
 import React, { ReactElement } from "react";
-
-const DOCS_URL =
-  "https://docs.exchangeunion.com/start-earning/market-maker-guide";
+import { XUD_DOCKER_DOCS_URL } from "../constants";
 
 function LinkToSetupGuide(): ReactElement {
   return (
@@ -11,7 +9,9 @@ function LinkToSetupGuide(): ReactElement {
       <Link
         component="button"
         color="textSecondary"
-        onClick={() => (window as any).electron.openExternal(DOCS_URL)}
+        onClick={() =>
+          (window as any).electron.openExternal(XUD_DOCKER_DOCS_URL)
+        }
       >
         How to set up XUD Docker
       </Link>

--- a/src/stores/WithStores.tsx
+++ b/src/stores/WithStores.tsx
@@ -1,0 +1,5 @@
+import { SettingsStore } from "./settingsStore";
+
+export interface WithStores {
+  settingsStore?: SettingsStore;
+}

--- a/src/stores/settingsStore.tsx
+++ b/src/stores/settingsStore.tsx
@@ -1,0 +1,43 @@
+import { observable, reaction } from "mobx";
+
+export type Settings = {
+  xudDockerUrl: string;
+};
+
+export type SettingsStore = ReturnType<typeof useSettingsStore>;
+
+export const SETTINGS_STORE = "settingsStore";
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const useSettingsStore = (defaultSettings: Settings) => {
+  const store = observable({
+    settings: defaultSettings,
+    get xudDockerUrl(): string {
+      return store.settings.xudDockerUrl;
+    },
+    setXudDockerUrl(url: string): void {
+      store.settings.xudDockerUrl = url;
+    },
+  });
+
+  updateFromLocalStorage(store);
+  addToLocalStorage(store);
+
+  return store;
+};
+
+function updateFromLocalStorage(store: SettingsStore): void {
+  const storedJson = localStorage.getItem(SETTINGS_STORE);
+  if (storedJson) {
+    Object.assign(store, JSON.parse(storedJson));
+  }
+}
+
+function addToLocalStorage(store: SettingsStore): void {
+  reaction(
+    () => JSON.stringify(store),
+    (json) => {
+      localStorage.setItem(SETTINGS_STORE, json);
+    }
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react",
+    "experimentalDecorators": true
   },
   "include": ["src"],
   "exclude": ["**/*.spec.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -8099,6 +8099,23 @@ mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@^0.5.4, mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mobx-react-lite@>=2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-2.2.2.tgz#87c217dc72b4e47b22493daf155daf3759f868a6"
+  integrity sha512-2SlXALHIkyUPDsV4VTKVR9DW7K3Ksh1aaIv3NrNJygTbhXe2A9GrcKHZ2ovIiOp/BXilOcTYemfHHZubP431dg==
+
+mobx-react@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/mobx-react/-/mobx-react-6.3.0.tgz#7d11799f988bbdadc49e725081993b18baa20329"
+  integrity sha512-C14yya2nqEBRSEiJjPkhoWJLlV8pcCX3m2JRV7w1KivwANJqipoiPx9UMH4pm6QNMbqDdvJqoyl+LqNu9AhvEQ==
+  dependencies:
+    mobx-react-lite ">=2.2.0"
+
+mobx@^5.15.7:
+  version "5.15.7"
+  resolved "https://registry.yarnpkg.com/mobx/-/mobx-5.15.7.tgz#b9a5f2b6251f5d96980d13c78e9b5d8d4ce22665"
+  integrity sha512-wyM3FghTkhmC+hQjyPGGFdpehrcX1KOXsDuERhfK2YbJemkUhEB+6wzEN639T21onxlfYBmriA1PFnvxTUhcKw==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
* The default url for the XUD Docker is `http://localhost:8889` (mainnet).
* In the _Connect remote XUD node_ view the user can set a custom url for the XUD Docker.
* The url will then be stored in `localStorage` and is preserved in case of refresh and restart.