### PR TITLE
feat: detect docker download status

### DIFF
--- a/public/ipc.js
+++ b/public/ipc.js
@@ -31,6 +31,7 @@ const ipcHandler = (mainWindow) => {
       docker_version: "docker version",
       docker_ps: "docker ps",
       docker_download: `curl ${DOCKER_BINARY_DOWNLOAD_URL} > ${DOCKER_INSTALLER_FILE_NAME}`,
+      docker_download_status: `dir | findstr /R "${DOCKER_INSTALLER_FILE_NAME}"`,
     };
     const command = AVAILABLE_COMMANDS[clientCommand];
     if (command) {


### PR DESCRIPTION
This commit adds support for detecting the Docker install status.
`dockerDownloadStatus$` returns a percentage value from 0% to 100%. This
value is calculated based on the size of the `docker-installer.exe`.