### PR TITLE
feat: docker backend fixes

### DIFF
--- a/public/ipc.js
+++ b/public/ipc.js
@@ -20,6 +20,7 @@ const AVAILABLE_COMMANDS = {
   restart: "shutdown /r",
   windows_version: "ver",
   docker_settings: "settings",
+  wsl_version: "wsl --set-default-version 2",
 };
 
 const execCommand = (cmd) => {

--- a/src/common/dockerUtil.ts
+++ b/src/common/dockerUtil.ts
@@ -34,6 +34,7 @@ const AVAILABLE_COMMANDS = {
   RESTART: "restart",
   WINDOWS_VERSION: "windows_version",
   SETTINGS: "docker_settings",
+  WSL_VERSION: "wsl_version",
 };
 
 const isDockerInstalled$ = (): Observable<boolean> => {
@@ -193,13 +194,15 @@ const dockerSettings$ = (): Observable<DockerSettings> => {
 };
 
 const isWSL2$ = (): Observable<boolean> => {
-  return windowsVersion$().pipe(
-    map((version) => {
-      const MINIMUM_WSL2_VERSION = 18917;
-      if (version >= MINIMUM_WSL2_VERSION) {
-        return true;
-      }
-      return false;
+  return execCommand$(AVAILABLE_COMMANDS.WSL_VERSION).pipe(
+    map((output) => {
+      const cleanedOutput = output.replace(/[^\w\s]/gi, '').trim()
+      console.log("output for isWSL2", cleanedOutput);
+      return !cleanedOutput.includes("requires an update");
+    }),
+    catchError((e: any) => {
+      console.error("Error detecting WSL version:", e);
+      return of(false);
     })
   );
 };

--- a/src/common/dockerUtil.ts
+++ b/src/common/dockerUtil.ts
@@ -196,7 +196,7 @@ const dockerSettings$ = (): Observable<DockerSettings> => {
 const isWSL2$ = (): Observable<boolean> => {
   return execCommand$(AVAILABLE_COMMANDS.WSL_VERSION).pipe(
     map((output) => {
-      const cleanedOutput = output.replace(/[^\w\s]/gi, '').trim()
+      const cleanedOutput = output.replace(/[^\w\s]/gi, "").trim();
       console.log("output for isWSL2", cleanedOutput);
       return !cleanedOutput.includes("requires an update");
     }),

--- a/src/setup/create/RestartRequired.tsx
+++ b/src/setup/create/RestartRequired.tsx
@@ -1,13 +1,39 @@
 import { Button, Grid, Typography } from "@material-ui/core";
 import ArrowRightAltIcon from "@material-ui/icons/ArrowRightAlt";
 import CheckIcon from "@material-ui/icons/Check";
-import React, { ReactElement } from "react";
-import { restart$ } from "../../common/dockerUtil";
+import React, { ReactElement, useEffect } from "react";
+import { combineLatest, of } from "rxjs";
+import { mergeMap } from "rxjs/operators";
+import {
+  DockerSettings,
+  dockerSettings$,
+  isWSL2$,
+  restart$,
+} from "../../common/dockerUtil";
 import LinkToDiscord from "../LinkToDiscord";
 import RowsContainer from "../RowsContainer";
 import InfoBar from "./InfoBar";
 
 const RestartRequired = (): ReactElement => {
+  useEffect(() => {
+    combineLatest([dockerSettings$(), isWSL2$()])
+      .pipe(
+        mergeMap(([dockerSettings, isWSL2]) => {
+          const { wslEngineEnabled } = dockerSettings as DockerSettings;
+          console.log("wslEngineEnabled", wslEngineEnabled);
+          console.log("isWSL2", isWSL2);
+          if (wslEngineEnabled && !isWSL2) {
+            console.log(
+              "TODO: change wslEngineEnabled to false since only WSL 1 is supported"
+            );
+          }
+          return of(true);
+        })
+      )
+      .subscribe((r) => {
+        console.log("settings have been updated", r);
+      });
+  });
   return (
     <RowsContainer>
       <Grid item container>

--- a/src/setup/create/next-route.test.ts
+++ b/src/setup/create/next-route.test.ts
@@ -107,6 +107,21 @@ describe("nextStep$", () => {
     assertNextStep(expectedPath, dockerInfo);
   });
 
+  it("directs to reboot when docker settings change required", () => {
+    const expectedPath = Path.RESTART_REQUIRED;
+    const dockerInfo = {
+      isDownloaded: false,
+      isInstalled: false,
+      isRunning: false,
+      rebootRequired: false,
+      isWSL2: false,
+      dockerSettings: {
+        wslEngineEnabled: true,
+      },
+    };
+    assertNextStep(expectedPath, dockerInfo);
+  });
+
   it("directs to starting xud", () => {
     const expectedPath = Path.STARTING_XUD;
     const dockerInfo = {

--- a/src/setup/create/next-route.ts
+++ b/src/setup/create/next-route.ts
@@ -37,11 +37,12 @@ const getNextRoute = (
         console.log("isDownloaded", isDownloaded);
         console.log("rebootRequired", rebootRequired);
         console.log("isWSL2", isWSL2);
-        console.log(
-          "dockerSettings",
-          (dockerSettings as DockerSettings).wslEngineEnabled
-        );
+        const { wslEngineEnabled } = dockerSettings as DockerSettings;
+        console.log("wslEngineEnabled", wslEngineEnabled);
         if (rebootRequired) {
+          return Path.RESTART_REQUIRED;
+        }
+        if (wslEngineEnabled && !isWSL2) {
           return Path.RESTART_REQUIRED;
         }
         if (isRunning) {


### PR DESCRIPTION
This PR makes preparations for enabling the application to change Docker's configuration file.

We add a reliable way to detect whether WSL1 or WSL2 is supported. When WSL2 is enabled as Docker backend we compare it to the system's supported WSL version. If there's a mismatch, we'll direct user to restart now screen.

In a follow-up PR, we'll add functionality to change Docker's WSL engine version.