### PR TITLE
fix: false positive for docker not installed

### DIFF
--- a/src/setup/create/next-route.test.ts
+++ b/src/setup/create/next-route.test.ts
@@ -147,4 +147,19 @@ describe("nextStep$", () => {
     };
     assertNextStep(expectedPath, dockerInfo);
   });
+
+  it("directs to waiting docker when unknown command, but settings file exists", () => {
+    const expectedPath = Path.WAITING_DOCKER_START;
+    const dockerInfo = {
+      isDownloaded: false,
+      isInstalled: false,
+      isRunning: false,
+      rebootRequired: false,
+      isWSL2: false,
+      dockerSettings: {
+        wslEngineEnabled: false,
+      },
+    };
+    assertNextStep(expectedPath, dockerInfo);
+  });
 });

--- a/src/setup/create/next-route.ts
+++ b/src/setup/create/next-route.ts
@@ -39,6 +39,8 @@ const getNextRoute = (
         console.log("isWSL2", isWSL2);
         const { wslEngineEnabled } = dockerSettings as DockerSettings;
         console.log("wslEngineEnabled", wslEngineEnabled);
+        const dockerSettingsExist = wslEngineEnabled !== undefined;
+        console.log("dockerSettingsExist", dockerSettingsExist);
         if (rebootRequired) {
           return Path.RESTART_REQUIRED;
         }
@@ -49,6 +51,9 @@ const getNextRoute = (
           return Path.STARTING_XUD;
         }
         if (isInstalled && !isRunning) {
+          return Path.WAITING_DOCKER_START;
+        }
+        if (!isInstalled && !isRunning && dockerSettingsExist) {
           return Path.WAITING_DOCKER_START;
         }
         if (!isDownloaded) {


### PR DESCRIPTION
This commit directs user to `WaitingDockerStart` screen when we detect that the settings file for docker exists.