### PR TITLE
feat: enable displaying 'Start' button in the landing page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,7 +85,7 @@ function App(): ReactElement {
             <Route path={Path.RESTART_REQUIRED}>
               <RestartRequired />
             </Route>
-            <Route path={Path.CREATE_ENVIRONMENT}>
+            <Route path={Path.START_ENVIRONMENT}>
               <Create />
             </Route>
             <Route path={Path.WAITING_DOCKER_START}>

--- a/src/router/Path.ts
+++ b/src/router/Path.ts
@@ -1,14 +1,14 @@
 export enum Path {
   CONNECT_TO_REMOTE = "/connect_remote",
-  CREATE_ENVIRONMENT = "/create_environment",
   DASHBOARD = "/dashboard",
   DOWNLOAD_DOCKER = "/download_docker",
-  WAITING_DOCKER_START = "/waiting_docker_start",
   HOME = "/",
   INSTALL_DOCKER = "/install_docker",
   OVERVIEW = "/overview",
   RESTART_REQUIRED = "/restart_required",
+  START_ENVIRONMENT = "/start_environment",
   STARTING_XUD = "/starting_xud",
   TRADEHISTORY = "/tradehistory",
+  WAITING_DOCKER_START = "/waiting_docker_start",
   WALLETS = "/wallets",
 }

--- a/src/setup/Landing.tsx
+++ b/src/setup/Landing.tsx
@@ -11,6 +11,7 @@ import {
 } from "@material-ui/core";
 import AddCircleTwoToneIcon from "@material-ui/icons/AddCircleTwoTone";
 import ArrowRightAltIcon from "@material-ui/icons/ArrowRightAlt";
+import PlayArrowTwoToneIcon from "@material-ui/icons/PlayArrowTwoTone";
 import PowerTwoToneIcon from "@material-ui/icons/PowerTwoTone";
 import { inject, observer } from "mobx-react";
 import React, { ElementType, useState } from "react";
@@ -28,12 +29,14 @@ type Item = {
   path: Path;
 };
 
-const createItems = (): Item[] => [
+const createItems = (envExists?: boolean): Item[] => [
   {
-    title: "Create",
-    additionalInfo: "Create new xud environment",
-    icon: AddCircleTwoToneIcon,
-    path: Path.CREATE_ENVIRONMENT,
+    title: envExists ? "Start" : "Create",
+    additionalInfo: envExists
+      ? "xud environment detected"
+      : "Create new xud environment",
+    icon: envExists ? PlayArrowTwoToneIcon : AddCircleTwoToneIcon,
+    path: Path.START_ENVIRONMENT,
   },
   {
     title: "Connect",
@@ -72,6 +75,7 @@ const Landing = inject(
   DOCKER_STORE
 )(
   observer(() => {
+    // TODO: pass in `true` as argument if environment is created
     const items: Item[] = createItems();
     const classes = useStyles();
     const history = useHistory();

--- a/src/setup/WaitingDockerStart.tsx
+++ b/src/setup/WaitingDockerStart.tsx
@@ -19,7 +19,7 @@ const WaitingDockerStart = (): ReactElement => {
         take(1)
       )
       .subscribe(() => {
-        history.push(Path.CREATE_ENVIRONMENT);
+        history.push(Path.START_ENVIRONMENT);
       });
   });
   return (

--- a/src/setup/create/DownloadDocker.tsx
+++ b/src/setup/create/DownloadDocker.tsx
@@ -65,7 +65,7 @@ const DownloadDocker = (): ReactElement => {
                 onClick={() => {
                   setIsDownloading(true);
                   downloadDocker$().subscribe(() =>
-                    history.push(Path.CREATE_ENVIRONMENT)
+                    history.push(Path.START_ENVIRONMENT)
                   );
                 }}
               >

--- a/src/setup/create/InstallDocker.tsx
+++ b/src/setup/create/InstallDocker.tsx
@@ -72,7 +72,7 @@ const InstallDocker = (): ReactElement => {
                   if (installSuccessful) {
                     localStorage.setItem("rebootRequired", "true");
                   }
-                  history.push(Path.CREATE_ENVIRONMENT);
+                  history.push(Path.START_ENVIRONMENT);
                 });
               }}
             >


### PR DESCRIPTION
This PR adds a possibility to dispay `Start` instead of `Create` in landing screen if an existing xud environment is detected.