### PR TITLE
feat: add a back button to 'Connect to remote screen'

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "main": "public/electron.js",
   "homepage": "./",
-  "version": "1.2.0-alpha.1",
+  "version": "1.2.0-alpha.2",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "main": "public/electron.js",
   "homepage": "./",
-  "version": "1.2.0-alpha.2",
+  "version": "1.2.0-alpha.3",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from "@material-ui/styles";
 import { Provider } from "mobx-react";
 import React, { ReactElement } from "react";
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { isWindows } from "./common/appUtil";
 import { XUD_DOCKER_LOCAL_MAINNET_URL } from "./constants";
 import Dashboard from "./dashboard/Dashboard";
 import { Path } from "./router/Path";
@@ -101,11 +102,7 @@ function App(): ReactElement {
               <IncorrectWslSettings />
             </Route>
             <Route path={Path.HOME}>
-              {(window as any).electron.platform() === "win32" ? (
-                <Landing />
-              ) : (
-                <DockerNotDetected />
-              )}
+              {isWindows() ? <Landing /> : <DockerNotDetected />}
             </Route>
           </Switch>
         </Router>

--- a/src/common/appUtil.ts
+++ b/src/common/appUtil.ts
@@ -1,0 +1,3 @@
+export const isWindows = (): boolean => {
+  return (window as any).electron.platform() === "win32";
+};

--- a/src/dashboard/eventHandler.ts
+++ b/src/dashboard/eventHandler.ts
@@ -1,11 +1,13 @@
 import { History } from "history";
+import { isWindows } from "../common/appUtil";
 import { Path } from "../router/Path";
 
 export const handleEvent = (event: MessageEvent, history: History): void => {
   const data: string = event.data;
 
   if (data.startsWith("disconnect")) {
-    history.push(Path.CONNECT_TO_REMOTE);
+    const nextPath = isWindows() ? Path.HOME : Path.CONNECT_TO_REMOTE;
+    history.push(nextPath);
     return;
   }
 

--- a/src/setup/ConnectToRemote.tsx
+++ b/src/setup/ConnectToRemote.tsx
@@ -145,7 +145,7 @@ const ConnectToRemote = inject(SETTINGS_STORE)(
           <Button
             variant="outlined"
             disableElevation
-            onClick={history.goBack}
+            onClick={() => history.push(Path.HOME)}
             startIcon={<ArrowBackIcon />}
           >
             Back

--- a/src/setup/ConnectToRemote.tsx
+++ b/src/setup/ConnectToRemote.tsx
@@ -9,6 +9,7 @@ import Button from "@material-ui/core/Button";
 import Grid from "@material-ui/core/Grid";
 import TextField from "@material-ui/core/TextField";
 import Typography from "@material-ui/core/Typography";
+import ArrowBackIcon from "@material-ui/icons/ArrowBack";
 import { History } from "history";
 import { inject, observer } from "mobx-react";
 import React, { useState } from "react";
@@ -139,6 +140,16 @@ const ConnectToRemote = inject(SETTINGS_STORE)(
               </Grid>
             </form>
           </Grid>
+        </Grid>
+        <Grid item container>
+          <Button
+            variant="outlined"
+            disableElevation
+            onClick={history.goBack}
+            startIcon={<ArrowBackIcon />}
+          >
+            Back
+          </Button>
         </Grid>
       </RowsContainer>
     );

--- a/src/setup/Landing.tsx
+++ b/src/setup/Landing.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
 } from "@material-ui/core";
 import AddCircleTwoToneIcon from "@material-ui/icons/AddCircleTwoTone";
-import ArrowRightAltIcon from "@material-ui/icons/ArrowRightAlt";
+import ArrowForwardIcon from "@material-ui/icons/ArrowForward";
 import PlayArrowTwoToneIcon from "@material-ui/icons/PlayArrowTwoTone";
 import PowerTwoToneIcon from "@material-ui/icons/PowerTwoTone";
 import { inject, observer } from "mobx-react";
@@ -135,7 +135,7 @@ const Landing = inject(
               variant="contained"
               color="primary"
               disableElevation
-              endIcon={<ArrowRightAltIcon />}
+              endIcon={<ArrowForwardIcon />}
               onClick={() => {
                 history.push(selectedItem!.path);
               }}

--- a/src/setup/create/DownloadDocker.tsx
+++ b/src/setup/create/DownloadDocker.tsx
@@ -5,7 +5,7 @@ import {
   makeStyles,
   Typography,
 } from "@material-ui/core";
-import ArrowRightAltIcon from "@material-ui/icons/ArrowRightAlt";
+import ArrowForwardIcon from "@material-ui/icons/ArrowForward";
 import React, { ReactElement, useState } from "react";
 import { useHistory } from "react-router-dom";
 import { downloadDocker$ } from "../../common/dockerUtil";
@@ -61,7 +61,7 @@ const DownloadDocker = (): ReactElement => {
                 variant="contained"
                 color="primary"
                 disableElevation
-                endIcon={<ArrowRightAltIcon />}
+                endIcon={<ArrowForwardIcon />}
                 onClick={() => {
                   setIsDownloading(true);
                   downloadDocker$().subscribe(() =>

--- a/src/setup/create/IncorrectWslSettings.tsx
+++ b/src/setup/create/IncorrectWslSettings.tsx
@@ -1,5 +1,5 @@
 import { Button, Grid, Typography } from "@material-ui/core";
-import ArrowRightAltIcon from "@material-ui/icons/ArrowRightAlt";
+import ArrowForwardIcon from "@material-ui/icons/ArrowForward";
 import ReportProblemOutlinedIcon from "@material-ui/icons/ReportProblemOutlined";
 import React, { ReactElement, useEffect } from "react";
 import { useHistory } from "react-router-dom";
@@ -73,7 +73,7 @@ const IncorrectWslSettings = (): ReactElement => {
             variant="contained"
             color="primary"
             disableElevation
-            endIcon={<ArrowRightAltIcon />}
+            endIcon={<ArrowForwardIcon />}
             onClick={() => {
               (window as any).electron.openExternal(WSL2_INSTALL_URL);
             }}

--- a/src/setup/create/InstallDocker.tsx
+++ b/src/setup/create/InstallDocker.tsx
@@ -1,5 +1,5 @@
 import { Button, Grid, Typography } from "@material-ui/core";
-import ArrowRightAltIcon from "@material-ui/icons/ArrowRightAlt";
+import ArrowForwardIcon from "@material-ui/icons/ArrowForward";
 import GetAppOutlinedIcon from "@material-ui/icons/GetAppOutlined";
 import React, { ReactElement, useState } from "react";
 import { useHistory } from "react-router-dom";
@@ -65,7 +65,7 @@ const InstallDocker = (): ReactElement => {
               variant="contained"
               color="primary"
               disableElevation
-              endIcon={<ArrowRightAltIcon />}
+              endIcon={<ArrowForwardIcon />}
               onClick={() => {
                 setIsInstalling(true);
                 installDocker$().subscribe((installSuccessful) => {

--- a/src/setup/create/RestartRequired.tsx
+++ b/src/setup/create/RestartRequired.tsx
@@ -1,5 +1,5 @@
 import { Button, Grid, Typography } from "@material-ui/core";
-import ArrowRightAltIcon from "@material-ui/icons/ArrowRightAlt";
+import ArrowForwardIcon from "@material-ui/icons/ArrowForward";
 import CheckIcon from "@material-ui/icons/Check";
 import React, { ReactElement, useEffect } from "react";
 import { combineLatest, of } from "rxjs";
@@ -58,7 +58,7 @@ const RestartRequired = (): ReactElement => {
             variant="contained"
             color="primary"
             disableElevation
-            endIcon={<ArrowRightAltIcon />}
+            endIcon={<ArrowForwardIcon />}
             onClick={() => {
               restart$().subscribe(() => {
                 window.close();


### PR DESCRIPTION
Closes https://github.com/ExchangeUnion/xud-ui/issues/82

Changed the arrow icons in the `Next` buttons on the way so that they would be of the same style as the one in the `Back` button.

The release can be found [here](https://github.com/ExchangeUnion/xud-ui/releases/tag/v1.2.0-alpha.2).