### PR TITLE
Chore/rebrand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ matrix:
         overwrite: true
         file_glob: true
         file:
-          - dist/xud-explorer-*.AppImage
-          - dist/xud-explorer*Setup*.exe
+          - dist/xud-ui-*.AppImage
+          - dist/xud-ui*Setup*.exe
         on:
           tags: true
 
@@ -39,7 +39,7 @@ matrix:
         api_key: $GITHUB_TOKEN
         overwrite: true
         file_glob: true
-        file: dist/xud-explorer-*.dmg
+        file: dist/xud-ui-*.dmg
         on:
           tags: true
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# XUD EXPLORER
+# XUD UI
 
 A graphical user interface for interacting with a [xud-docker](https://github.com/ExchangeUnion/xud-docker) environment.
 
@@ -26,7 +26,7 @@ A graphical user interface for interacting with a [xud-docker](https://github.co
 
 ## Getting started
 
-- Download and run the XUD Explorer executable. The latest release can be found [here](https://github.com/ExchangeUnion/xud-ui/releases/latest).
+- Download and run the XUD UI executable. The latest release can be found [here](https://github.com/ExchangeUnion/xud-ui/releases/latest).
 
 - Make sure to have a [xud-docker](https://github.com/ExchangeUnion/xud-docker) environment running with API enabled. You can do that by either entering the environment with `bash xud.sh --proxy.disabled=false` or enabling the API permanently in `mainnet.conf`:
 
@@ -40,23 +40,23 @@ expose-ports = ["8889"]
   - mainnet: 8889 (`localhost:8889`) - _default_
   - testnet: 18889 (`localhost:18889`)
   - simnet: 28889 (`localhost:28889`)
-- If you are running xud-docker mainnet locally, XUD Explorer connects automatically to this instance
+- If you are running xud-docker mainnet locally, XUD UI connects automatically to this instance
 
 ## Application logs
 
 Logs are written to the following locations
 
-- on Linux: ~/.config/xud-explorer/logs/
-- on macOS: ~/Library/Logs/xud-explorer/
-- on Windows: %USERPROFILE%\AppData\Roaming\xud-explorer\logs\
+- on Linux: ~/.config/xud-ui/logs/
+- on macOS: ~/Library/Logs/xud-ui/
+- on Windows: %USERPROFILE%\AppData\Roaming\xud-ui\logs\
 
 ## Application data
 
 Application data is stored in the following locations
 
-- on Linux: ~/.config/xud-explorer/
-- on macOS: ~/Library/Application\ Support/xud-explorer/
-- on Windows: %USERPROFILE%\AppData\Roaming\xud-explorer\
+- on Linux: ~/.config/xud-ui/
+- on macOS: ~/Library/Application\ Support/xud-ui/
+- on Windows: %USERPROFILE%\AppData\Roaming\xud-ui\
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "xud-explorer",
+  "name": "xud-ui",
   "description": "For market makers who want to have a visual way to control their xud environment",
   "author": "Exchange Union",
   "build": {
-    "appId": "com.xud-explorer",
+    "appId": "com.xud-ui",
     "linux": {
       "category": "Finance",
       "icon": "public/assets/512x512.png"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "main": "public/electron.js",
   "homepage": "./",
-  "version": "1.2.0-alpha.3",
+  "version": "1.2.0-alpha.4",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
       content="UI for market makers who want to have a visual way to control their xud environment"
     />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>XUD Explorer</title>
+    <title>XUD UI</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "XUD Explorer",
-  "name": "XUD Explorer",
+  "short_name": "XUD UI",
+  "name": "XUD UI",
   "icons": [
     {
       "src": "assets/512x512.png",

--- a/src/dashboard/Dashboard.tsx
+++ b/src/dashboard/Dashboard.tsx
@@ -40,7 +40,7 @@ const Dashboard = inject(SETTINGS_STORE)(
         <iframe
           className={classes.iframe}
           src={settingsStore!.xudDockerUrl}
-          title="XUD Explorer Dashboard"
+          title="XUD UI Dashboard"
         />
       );
     }

--- a/src/setup/create/RestartRequired.tsx
+++ b/src/setup/create/RestartRequired.tsx
@@ -49,7 +49,7 @@ const RestartRequired = (): ReactElement => {
           color="textSecondary"
           align="center"
         >
-          After reboot, please reopen XUD Explorer.
+          After reboot, please reopen XUD UI.
         </Typography>
       </Grid>
       <Grid item container justify="flex-end">


### PR DESCRIPTION
This PR renames the app back to `XUD UI` until it has a proper name.
The release can be found [here](https://github.com/ExchangeUnion/xud-ui/releases/tag/v1.2.0-alpha.4).