### PR TITLE
feat: prevent docker first time start screen to appear

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "main": "public/electron.js",
   "homepage": "./",
-  "version": "1.2.0-alpha.4",
+  "version": "1.2.0-alpha.5",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",

--- a/public/ipc.js
+++ b/public/ipc.js
@@ -10,7 +10,13 @@ const DOCKER_BINARY_DOWNLOAD_URL =
   "https://desktop.docker.com/win/stable/Docker%20Desktop%20Installer.exe";
 const DOCKER_INSTALLER_FILE_NAME = "docker-installer.exe";
 
-const WINDOWS_DOCKER_EXECUTABLE_PATH = "C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe";
+const WINDOWS_DOCKER_EXECUTABLE_PATH =
+  "C:\\Program Files\\Docker\\Docker\\Docker Desktop.exe";
+
+const DOCKER_SETTINGS_PATH = path.join(
+  os.homedir(),
+  "AppData/Roaming/Docker/settings.json"
+);
 
 // List of commands we're allowing the client to execute.
 const AVAILABLE_COMMANDS = {
@@ -22,6 +28,7 @@ const AVAILABLE_COMMANDS = {
   restart: "shutdown /r",
   windows_version: "ver",
   docker_settings: "settings",
+  modify_docker_settings: "settings modify",
   wsl_version: "wsl --set-default-version 2",
   pull_exp: "docker pull exchangeunion/exp",
   start_docker: `"${WINDOWS_DOCKER_EXECUTABLE_PATH}"`,
@@ -31,31 +38,41 @@ const AVAILABLE_COMMANDS = {
 
 const execCommand = (cmd) => {
   const cmd$ = new Observable((subscriber) => {
-    if (cmd === AVAILABLE_COMMANDS["docker_settings"]) {
-      const dockerSettingsPath = path.join(
-        os.homedir(),
-        "AppData/Roaming/Docker/settings.json"
-      );
-      fs.readFile(dockerSettingsPath, { encoding: "utf-8" }, function (
+    const handleResponse = (result, error) => {
+      if (!error) {
+        subscriber.next(result);
+        subscriber.complete();
+      } else {
+        subscriber.error(error);
+      }
+    };
+
+    if (cmd === AVAILABLE_COMMANDS.docker_settings) {
+      fs.readFile(DOCKER_SETTINGS_PATH, { encoding: "utf-8" }, function (
         err,
         settings
       ) {
-        if (!err) {
-          subscriber.next(settings);
-          subscriber.complete();
-        } else {
-          subscriber.error(err);
+        handleResponse(settings, err);
+      });
+    } else if (cmd === AVAILABLE_COMMANDS.modify_docker_settings) {
+      fs.readFile(DOCKER_SETTINGS_PATH, { encoding: "utf-8" }, function (
+        err,
+        settings
+      ) {
+        if (err) {
+          handleResponse(undefined, err);
         }
+        const settingsObject = JSON.parse(settings);
+        settingsObject.displayedTutorial = true;
+        settingsObject.autoStart = false;
+        fs.writeFile(
+          DOCKER_SETTINGS_PATH,
+          JSON.stringify(settingsObject),
+          (err) => handleResponse(undefined, err)
+        );
       });
     } else {
-      exec(cmd, (error, stdout) => {
-        if (error) {
-          subscriber.error(error);
-          return;
-        }
-        subscriber.next(stdout);
-        subscriber.complete();
-      });
+      exec(cmd, (error, stdout) => handleResponse(stdout, error));
     }
   });
   return cmd$;

--- a/src/common/dockerUtil.ts
+++ b/src/common/dockerUtil.ts
@@ -34,6 +34,7 @@ const AVAILABLE_COMMANDS = {
   RESTART: "restart",
   WINDOWS_VERSION: "windows_version",
   SETTINGS: "docker_settings",
+  MODIFY_DOCKER_SETTINGS: "modify_docker_settings",
   WSL_VERSION: "wsl_version",
   PULL_EXP: "pull_exp",
   START_DOCKER: "start_docker",
@@ -211,6 +212,18 @@ const dockerSettings$ = (): Observable<DockerSettings> => {
   );
 };
 
+const modifyDockerSettings$ = (): Observable<boolean> => {
+  return execCommand$(AVAILABLE_COMMANDS.MODIFY_DOCKER_SETTINGS).pipe(
+    map(() => {
+      return true;
+    }),
+    catchError((e: any) => {
+      console.error("Error modifying Docker settings:", e);
+      return of(false);
+    })
+  );
+};
+
 const isWSL2$ = (): Observable<boolean> => {
   return execCommand$(AVAILABLE_COMMANDS.WSL_VERSION).pipe(
     map((output) => {
@@ -263,6 +276,7 @@ export {
   windowsVersion$,
   isWSL2$,
   dockerSettings$,
+  modifyDockerSettings$,
   pullExp$,
   startXudDocker$,
   startDocker$,


### PR DESCRIPTION
Closes https://github.com/ExchangeUnion/xud-ui/issues/77

Changed the Docker config so that the `displayedTutorial` value is immediately marked as `true`. This prevents showing the tutorial.

Also changed the `autoStart` option in the settings to `false`. This should prevent Docker automatically starting on system startup. However, it did not have any effect when I tested it. There does not seem to be a separate option for preventing the window to appear. I suggest we do not waste more time on this.

The release can be found [here](https://github.com/ExchangeUnion/xud-ui/releases/tag/v1.2.0-alpha.5).