### PR TITLE
chore: trigger ci builds on both pushes and pull requests to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   build:


### PR DESCRIPTION
Currently, when a pull request is created from a fork, the build does not trigger.
This PR would solve this issue.