### PR TITLE
chore: add release-drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,4 @@
+template: |
+  ## What’s Changed
+
+  $CHANGES


### PR DESCRIPTION
The release-drafter config is always read from the master branch, so it needs to be merged before the whole implementation of https://github.com/ExchangeUnion/xud-ui/pull/131 can be fully tested. 