### PR TITLE
fix: prevent empty screen instead of dashboard; log to file

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "main": "public/electron.js",
   "homepage": "./",
-  "version": "1.2.1-alpha.3",
+  "version": "1.2.1-alpha.4",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,6 +101,9 @@ function App(): ReactElement {
             <Route path={Path.INCOMPATIBLE_WSL_SETTINGS}>
               <IncorrectWslSettings />
             </Route>
+            <Route path={Path.CONNECTION_LOST}>
+              <DockerNotDetected />
+            </Route>
             <Route path={Path.HOME}>
               {isWindows() ? <Landing /> : <DockerNotDetected />}
             </Route>

--- a/src/common/appUtil.ts
+++ b/src/common/appUtil.ts
@@ -1,3 +1,11 @@
 export const isWindows = (): boolean => {
   return (window as any).electron.platform() === "win32";
 };
+
+export const logError = (...message: any[]): void => {
+  (window as any).electron.logError(message.join("\n"));
+};
+
+export const logInfo = (...message: any[]): void => {
+  (window as any).electron.logInfo(message.join("\n"));
+};

--- a/src/common/dockerUtil.ts
+++ b/src/common/dockerUtil.ts
@@ -2,6 +2,7 @@ import { Observable, of } from "rxjs";
 import { catchError, map, take } from "rxjs/operators";
 import { v4 as uuidv4 } from "uuid";
 import { Network } from "../enums";
+import { logError, logInfo } from "./appUtil";
 
 const execCommand$ = (command: string): Observable<string> => {
   return new Observable((subscriber) => {
@@ -58,7 +59,7 @@ const isDockerInstalled$ = (): Observable<boolean> => {
       ) {
         return of(false);
       }
-      console.error("Error checking Docker installed status:", e);
+      logError("Error checking Docker installed status:", e);
       return of(false);
     })
   );
@@ -80,35 +81,35 @@ const isDockerRunning$ = (): Observable<boolean> => {
       ) {
         return of(false);
       }
-      console.error("Error checking Docker running status:", e);
+      logError("Error checking Docker running status:", e);
       return of(false);
     })
   );
 };
 
 const downloadDocker$ = (): Observable<boolean> => {
-  console.log("starting docker download");
+  logInfo("starting docker download");
   return execCommand$(AVAILABLE_COMMANDS.DOWNLOAD).pipe(
     map((output) => {
-      console.log("output from downloadDocker$", output);
+      logInfo("output from downloadDocker$", output);
       return true;
     }),
     catchError((e: any) => {
-      console.error("Error downloading Docker:", e);
+      logError("Error downloading Docker:", e);
       return of(false);
     })
   );
 };
 
 const installDocker$ = (): Observable<boolean> => {
-  console.log("starting docker install");
+  logInfo("starting docker install");
   return execCommand$(AVAILABLE_COMMANDS.INSTALL).pipe(
     map((output) => {
-      console.log("output from installDocker$", output);
+      logInfo("output from installDocker$", output);
       return true;
     }),
     catchError((e: any) => {
-      console.error("Error installing Docker:", e);
+      logError("Error installing Docker:", e);
       return of(false);
     }),
     take(1)
@@ -116,14 +117,14 @@ const installDocker$ = (): Observable<boolean> => {
 };
 
 const startDocker$ = (): Observable<boolean> => {
-  console.log("starting docker");
+  logInfo("starting docker");
   return execCommand$(AVAILABLE_COMMANDS.START_DOCKER).pipe(
     map((output) => {
-      console.log("output from startDocker$", output);
+      logInfo("output from startDocker$", output);
       return true;
     }),
     catchError((e: any) => {
-      console.error("Error starting Docker:", e);
+      logError("Error starting Docker:", e);
       return of(false);
     }),
     take(1)
@@ -133,7 +134,7 @@ const startDocker$ = (): Observable<boolean> => {
 const dockerDownloadStatus$ = (): Observable<number> => {
   return execCommand$(AVAILABLE_COMMANDS.DOWNLOAD_STATUS).pipe(
     map((output) => {
-      console.log("output from isDockerDownloaded$", output);
+      logInfo("output from isDockerDownloaded$", output);
       const isDownloaded = output.includes("docker-installer.exe");
       if (isDownloaded) {
         return 100;
@@ -144,7 +145,7 @@ const dockerDownloadStatus$ = (): Observable<number> => {
       if (e.message?.includes("Command failed: dir | findstr /R")) {
         return of(0);
       }
-      console.error("Error checking if Docker is downloaded:", e);
+      logError("Error checking if Docker is downloaded:", e);
       return of(0);
     })
   );
@@ -179,7 +180,7 @@ const rebootRequired$ = (): Observable<boolean> => {
 const windowsVersion$ = (): Observable<number> => {
   return execCommand$(AVAILABLE_COMMANDS.WINDOWS_VERSION).pipe(
     map((output) => {
-      console.log("version output", output);
+      logInfo("version output", output);
       // We parse the output of "ver" command and determine if
       // the next-to-last numeric group version 18917 or higher?
       // 1. LOWER => WSL1
@@ -191,7 +192,7 @@ const windowsVersion$ = (): Observable<number> => {
       return parseInt(versionString[0].split(".")[2]);
     }),
     catchError((e: any) => {
-      console.error("Error detecting Windows version:", e);
+      logError("Error detecting Windows version:", e);
       return of(10);
     })
   );
@@ -207,7 +208,7 @@ const dockerSettings$ = (): Observable<DockerSettings> => {
       return (JSON.parse(output) as unknown) as DockerSettings;
     }),
     catchError((e: any) => {
-      console.error("Error detecting Docker settings:", e);
+      logError("Error detecting Docker settings:", e);
       return of({});
     })
   );
@@ -219,7 +220,7 @@ const modifyDockerSettings$ = (): Observable<boolean> => {
       return true;
     }),
     catchError((e: any) => {
-      console.error("Error modifying Docker settings:", e);
+      logError("Error modifying Docker settings:", e);
       return of(false);
     })
   );
@@ -229,11 +230,11 @@ const isWSL2$ = (): Observable<boolean> => {
   return execCommand$(AVAILABLE_COMMANDS.WSL_VERSION).pipe(
     map((output) => {
       const cleanedOutput = output.replace(/[^\w\s]/gi, "").trim();
-      console.log("output for isWSL2", cleanedOutput);
+      logInfo("output for isWSL2", cleanedOutput);
       return !cleanedOutput.includes("requires an update");
     }),
     catchError((e: any) => {
-      console.error("Error detecting WSL version:", e);
+      logError("Error detecting WSL version:", e);
       return of(false);
     })
   );
@@ -242,12 +243,8 @@ const isWSL2$ = (): Observable<boolean> => {
 const startXudDocker$ = (): Observable<boolean> => {
   return execCommand$(AVAILABLE_COMMANDS.SETUP_XUD_DOCKER).pipe(
     map((output) => {
-      console.log("output for start xud-docker", output);
+      logInfo("output for start xud-docker", output);
       return true;
-    }),
-    catchError((e: any) => {
-      console.error("Error starting xud-docker:", e);
-      return of(false);
     })
   );
 };

--- a/src/dashboard/Dashboard.tsx
+++ b/src/dashboard/Dashboard.tsx
@@ -30,7 +30,7 @@ const Dashboard = inject(SETTINGS_STORE)(
       useEffect(() => {
         api.statusByService$("proxy", settingsStore!.xudDockerUrl).subscribe({
           next: () => {},
-          error: () => history.push(Path.HOME),
+          error: () => history.push(Path.CONNECTION_LOST),
         });
         const messageListenerHandler = (event: MessageEvent) => {
           if (event.origin === settingsStore!.xudDockerUrl) {

--- a/src/dashboard/Dashboard.tsx
+++ b/src/dashboard/Dashboard.tsx
@@ -2,6 +2,8 @@ import { createStyles, makeStyles } from "@material-ui/core/styles";
 import { inject, observer } from "mobx-react";
 import React, { ReactElement, useEffect } from "react";
 import { useHistory } from "react-router-dom";
+import api from "../api";
+import { Path } from "../router/Path";
 import { SETTINGS_STORE } from "../stores/settingsStore";
 import { WithStores } from "../stores/WithStores";
 import { handleEvent } from "./eventHandler";
@@ -26,6 +28,10 @@ const Dashboard = inject(SETTINGS_STORE)(
       const { settingsStore } = props;
 
       useEffect(() => {
+        api.statusByService$("proxy", settingsStore!.xudDockerUrl).subscribe({
+          next: () => {},
+          error: () => history.push(Path.HOME),
+        });
         const messageListenerHandler = (event: MessageEvent) => {
           if (event.origin === settingsStore!.xudDockerUrl) {
             handleEvent(event, history);

--- a/src/dashboard/eventHandler.ts
+++ b/src/dashboard/eventHandler.ts
@@ -12,7 +12,7 @@ export const handleEvent = (event: MessageEvent, history: History): void => {
   }
 
   if (data.startsWith("connectionFailed")) {
-    history.push(Path.HOME);
+    history.push(Path.CONNECTION_LOST);
     return;
   }
 

--- a/src/router/Path.ts
+++ b/src/router/Path.ts
@@ -1,5 +1,6 @@
 export enum Path {
   CONNECT_TO_REMOTE = "/connect_remote",
+  CONNECTION_LOST = "/connection_lost",
   DASHBOARD = "/dashboard",
   DOWNLOAD_DOCKER = "/download_docker",
   HOME = "/",

--- a/src/setup/DockerNotDetected.tsx
+++ b/src/setup/DockerNotDetected.tsx
@@ -15,6 +15,7 @@ import { Link as RouterLink, useHistory } from "react-router-dom";
 import { timer } from "rxjs";
 import { delay, mergeMap, retryWhen } from "rxjs/operators";
 import api from "../api";
+import { isWindows } from "../common/appUtil";
 import { Path } from "../router/Path";
 import { DOCKER_STORE } from "../stores/dockerStore";
 import { SETTINGS_STORE } from "../stores/settingsStore";
@@ -28,6 +29,9 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     spinnerContainer: {
       padding: theme.spacing(8),
+    },
+    titleContainer: {
+      padding: theme.spacing(2),
     },
   })
 );
@@ -66,18 +70,28 @@ const DockerNotDetected = inject(
             justify="center"
             wrap="nowrap"
             spacing={2}
+            className={classes.titleContainer}
           >
             <Grid item>
               <ReportProblemOutlinedIcon fontSize="large" />
             </Grid>
             <Grid item>
-              <Typography variant="h4" component="h1">
-                {connectionFailed
+              <Typography variant="h4" component="h1" align="center">
+                {isWindows()
+                  ? "Connection to XUD Docker lost"
+                  : connectionFailed
                   ? "Unable to connect to XUD Docker"
                   : "Waiting for XUD Docker"}
               </Typography>
             </Grid>
           </Grid>
+          {isWindows() && (
+            <Grid item container alignItems="center" justify="center">
+              <Typography variant="body1" align="center">
+                Trying to reconnect. Please check your environment.
+              </Typography>
+            </Grid>
+          )}
           {!connectionFailed && (
             <Grid
               container
@@ -91,16 +105,16 @@ const DockerNotDetected = inject(
           <Grid container item alignItems="center" justify="center">
             <Button
               component={RouterLink}
-              to={Path.CONNECT_TO_REMOTE}
+              to={isWindows() ? Path.HOME : Path.CONNECT_TO_REMOTE}
               variant="outlined"
               endIcon={<ArrowForwardIcon />}
             >
-              Connect remote XUD Docker
+              {isWindows() ? "Go To Start Page" : "Connect remote XUD Docker"}
             </Button>
           </Grid>
         </Grid>
         <Grid container item alignItems="center">
-          <LinkToSetupGuide />
+          {!isWindows() && <LinkToSetupGuide />}
         </Grid>
       </RowsContainer>
     );

--- a/src/setup/create/RestartRequired.tsx
+++ b/src/setup/create/RestartRequired.tsx
@@ -4,6 +4,7 @@ import CheckIcon from "@material-ui/icons/Check";
 import React, { ReactElement, useEffect } from "react";
 import { combineLatest, of } from "rxjs";
 import { mergeMap } from "rxjs/operators";
+import { logInfo } from "../../common/appUtil";
 import {
   DockerSettings,
   dockerSettings$,
@@ -20,10 +21,10 @@ const RestartRequired = (): ReactElement => {
       .pipe(
         mergeMap(([dockerSettings, isWSL2]) => {
           const { wslEngineEnabled } = dockerSettings as DockerSettings;
-          console.log("wslEngineEnabled", wslEngineEnabled);
-          console.log("isWSL2", isWSL2);
+          logInfo("wslEngineEnabled", wslEngineEnabled);
+          logInfo("isWSL2", isWSL2);
           if (wslEngineEnabled && !isWSL2) {
-            console.log(
+            logInfo(
               "TODO: change wslEngineEnabled to false since only WSL 1 is supported"
             );
           }
@@ -31,7 +32,7 @@ const RestartRequired = (): ReactElement => {
         })
       )
       .subscribe((r) => {
-        console.log("settings have been updated", r);
+        logInfo("settings have been updated", r);
       });
   });
   return (

--- a/src/setup/create/next-route.test.ts
+++ b/src/setup/create/next-route.test.ts
@@ -66,6 +66,9 @@ describe("nextStep$", () => {
     testScheduler = new TestScheduler((actual, expected) => {
       expect(actual).toEqual(expected);
     });
+    (window as any).electron = {
+      logInfo: () => {},
+    };
   });
 
   it("directs to download", () => {

--- a/src/setup/create/next-route.ts
+++ b/src/setup/create/next-route.ts
@@ -1,5 +1,6 @@
 import { combineLatest, Observable } from "rxjs";
 import { map, take } from "rxjs/operators";
+import { logInfo } from "../../common/appUtil";
 import { DockerSettings } from "../../common/dockerUtil";
 import { Path } from "../../router/Path";
 
@@ -32,15 +33,15 @@ const getNextRoute = (
         isWSL2,
         dockerSettings,
       ]) => {
-        console.log("isInstalled", isInstalled);
-        console.log("isRunning", isRunning);
-        console.log("isDownloaded", isDownloaded);
-        console.log("rebootRequired", rebootRequired);
-        console.log("isWSL2", isWSL2);
+        logInfo("isInstalled", isInstalled);
+        logInfo("isRunning", isRunning);
+        logInfo("isDownloaded", isDownloaded);
+        logInfo("rebootRequired", rebootRequired);
+        logInfo("isWSL2", isWSL2);
         const { wslEngineEnabled } = dockerSettings as DockerSettings;
-        console.log("wslEngineEnabled", wslEngineEnabled);
+        logInfo("wslEngineEnabled", wslEngineEnabled);
         const dockerSettingsExist = wslEngineEnabled !== undefined;
-        console.log("dockerSettingsExist", dockerSettingsExist);
+        logInfo("dockerSettingsExist", dockerSettingsExist);
         if (rebootRequired) {
           return Path.RESTART_REQUIRED;
         }


### PR DESCRIPTION
Fixes the following issues:
- when the `setup` command of xud-launcher results in error, an error message and `Retry` button is displayed. If the detailed error message cannot be found from the response, the user is recommended to see the details from the application logs;
- on navigating to the dashboard, it is checked if connection to the xud-docker-api can be established. If not, the user is redirected to the home page;
- all errors and info messages are now logged to the file instead of console.

The release can be found [here](https://github.com/ExchangeUnion/xud-ui/releases/tag/v1.2.1-alpha.1).