### PR TITLE
Fix/reopen

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "main": "public/electron.js",
   "homepage": "./",
-  "version": "1.2.1-alpha.2",
+  "version": "1.2.1-alpha.3",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "main": "public/electron.js",
   "homepage": "./",
-  "version": "1.2.0",
+  "version": "1.2.1-alpha.2",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",

--- a/public/electron.js
+++ b/public/electron.js
@@ -163,9 +163,7 @@ app.on("will-quit", (e) => {
 });
 
 app.on("activate", () => {
-  if (mainWindow === null) {
-    createWindow();
-  }
+  mainWindow ? mainWindow.show() : createWindow();
 });
 
 // SSL/TSL: self signed certificate support

--- a/public/electron.js
+++ b/public/electron.js
@@ -42,12 +42,14 @@ function createWindow() {
       handleMainWindowHideActions(e);
     }
   });
+  mainWindow.on("minimize", () => tray.setContextMenu(trayMenuWithShow));
+  mainWindow.on("show", () => tray.setContextMenu(trayMenuWithHide));
 }
 
 const handleMoveToTrayNotification = () => {
   const notification = {
     title: "XUD UI is still running",
-    body: "Select shutdown here if you want to shutdown your environment",
+    body: "Select shutdown here if you want to shutdown your local environment",
   };
   new Notification(notification).show();
 };
@@ -55,15 +57,14 @@ const handleMoveToTrayNotification = () => {
 const handleShutdownNotification = () => {
   const notification = {
     title: "Shutdown",
-    body: "All docker containers will be stopped",
+    body: "All locally running xud-docker containers will be stopped",
   };
   new Notification(notification).show();
 };
 
 const handleMainWindowHideActions = (e) => {
   e.preventDefault();
-  mainWindow.hide();
-  tray.setContextMenu(trayMenuWithShow);
+  handleHideActions();
   handleMoveToTrayNotification();
 };
 
@@ -76,7 +77,6 @@ const handleShutdownActions = () => {
 
 const handleShowActions = () => {
   mainWindow.show();
-  tray.setContextMenu(trayMenuWithHide);
 };
 
 const handleHideActions = () => {
@@ -119,11 +119,9 @@ app
     tray.setContextMenu(trayMenuWithHide);
     tray.on("double-click", () => {
       if (mainWindow.isVisible()) {
-        mainWindow.hide();
-        tray.setContextMenu(trayMenuWithShow);
+        handleHideActions();
       } else {
-        mainWindow.show();
-        tray.setContextMenu(trayMenuWithHide);
+        handleShowActions();
       }
     });
   })
@@ -137,8 +135,7 @@ if (!gotTheLock) {
 } else {
   app.on("second-instance", () => {
     if (mainWindow) {
-      mainWindow.isMinimized() && mainWindow.restore();
-      mainWindow.focus();
+      handleShowActions();
     }
   });
 }


### PR DESCRIPTION
Closes https://github.com/ExchangeUnion/xud-ui/issues/140
Also fixes some cases when `Show` and `Hide` of the tray icon were not correctly shown.
Fixes a bug on MacOS when window could not be reopened after closing it.
Modified the notifications that appear on closing window / shutdown to indicate that it only affects the local xud-docker environments.

The release can be found [here](https://github.com/ExchangeUnion/xud-ui/releases/tag/v1.2.1-alpha.3).