### PR TITLE
feat: add folder browsing and knowledge of current connection type

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "main": "public/electron.js",
   "homepage": "./",
-  "version": "1.2.1",
+  "version": "1.3.0-alpha.1",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.32",

--- a/public/electron.js
+++ b/public/electron.js
@@ -24,6 +24,7 @@ function createWindow() {
       preload: path.join(__dirname, "./preload.js"),
       worldSafeExecuteJavaScript: true,
       contextIsolation: true,
+      enableRemoteModule: true,
     },
   });
   mainWindow.loadURL(

--- a/public/preload.js
+++ b/public/preload.js
@@ -1,4 +1,4 @@
-const { clipboard, contextBridge, shell } = require("electron");
+const { clipboard, contextBridge, shell, remote } = require("electron");
 const log = require("electron-log");
 const { ipcRenderer } = require("electron");
 const fs = require("fs");
@@ -28,14 +28,19 @@ contextBridge.exposeInMainWorld("electron", {
     log.info(message);
   },
   xudDockerEnvExists: (network) => {
-  let pathFromHomedir = "";
-  // TODO: implement for macos and linux
-  if (process.platform === "win32") {
-    pathFromHomedir = "AppData/Local/XudDocker";
-  }
-  return fs.existsSync(
-    path.join(os.homedir(),
-    `${pathFromHomedir}/${network}/data/xud/nodekey.dat`)
-  );
+    let pathFromHomedir = "";
+    // TODO: implement for macos and linux
+    if (process.platform === "win32") {
+      pathFromHomedir = "AppData/Local/XudDocker";
+    }
+    return fs.existsSync(
+      path.join(
+        os.homedir(),
+        `${pathFromHomedir}/${network}/data/xud/nodekey.dat`
+      )
+    );
+  },
+  dialog: () => {
+    return remote.dialog;
   },
 });

--- a/src/dashboard/Dashboard.tsx
+++ b/src/dashboard/Dashboard.tsx
@@ -34,7 +34,7 @@ const Dashboard = inject(SETTINGS_STORE)(
         });
         const messageListenerHandler = (event: MessageEvent) => {
           if (event.origin === settingsStore!.xudDockerUrl) {
-            handleEvent(event, history);
+            handleEvent(event, history, settingsStore!);
           }
         };
         window.addEventListener("message", messageListenerHandler);

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -3,3 +3,8 @@ export enum Network {
   TESTNET = "testnet",
   SIMNET = "simnet",
 }
+
+export enum ConnectionType {
+  LOCAL = "local",
+  REMOTE = "remote",
+}

--- a/src/setup/ConnectToRemote.tsx
+++ b/src/setup/ConnectToRemote.tsx
@@ -20,6 +20,7 @@ import { Path } from "../router/Path";
 import { SETTINGS_STORE } from "../stores/settingsStore";
 import { WithStores } from "../stores/WithStores";
 import RowsContainer from "./RowsContainer";
+import { ConnectionType } from "../enums";
 
 type ConnectToRemoteProps = WithStores;
 
@@ -141,7 +142,8 @@ const ConnectToRemote = inject(SETTINGS_STORE)(
                           setConnecting,
                           history,
                           ipAndPort,
-                          settingsStore!.setXudDockerUrl
+                          settingsStore!.setXudDockerUrl,
+                          settingsStore!.setConnectionType
                         )
                       }
                     >
@@ -180,7 +182,8 @@ const handleConnectClick = (
   setConnecting: (value: boolean) => void,
   history: History,
   xudDockerUrl: string,
-  setXudDockerUrl: (ip: string) => void
+  setXudDockerUrl: (ip: string) => void,
+  setConnectionType: (type: ConnectionType) => void
 ): void => {
   setConnecting(true);
   api.statusByService$("xud", xudDockerUrl).subscribe({
@@ -188,6 +191,7 @@ const handleConnectClick = (
       setConnectionFailed(false);
       setConnecting(false);
       setXudDockerUrl(xudDockerUrl);
+      setConnectionType(ConnectionType.REMOTE);
       history.push(Path.DASHBOARD);
     },
     error: () => {

--- a/src/setup/create/StartingXud.tsx
+++ b/src/setup/create/StartingXud.tsx
@@ -14,6 +14,7 @@ import api from "../../api";
 import { logError, logInfo } from "../../common/appUtil";
 import { startXudDocker$ } from "../../common/dockerUtil";
 import { XUD_DOCKER_LOCAL_MAINNET_URL } from "../../constants";
+import { ConnectionType } from "../../enums";
 import { Path } from "../../router/Path";
 import { SETTINGS_STORE } from "../../stores/settingsStore";
 import { WithStores } from "../../stores/WithStores";
@@ -67,6 +68,7 @@ const StartingXud = inject(SETTINGS_STORE)(
           },
           complete: () => {
             setProgress(100);
+            settingsStore!.setConnectionType(ConnectionType.LOCAL);
             setTimeout(() => setShowContent(false), 500);
             setTimeout(() => history.push(Path.DASHBOARD), 1000);
           },

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1,7 +1,9 @@
 import { observable, reaction } from "mobx";
+import { ConnectionType } from "../enums";
 
 export type Settings = {
   xudDockerUrl: string;
+  connectionType?: ConnectionType;
 };
 
 export type SettingsStore = ReturnType<typeof useSettingsStore>;
@@ -17,6 +19,12 @@ export const useSettingsStore = (defaultSettings: Settings) => {
     },
     setXudDockerUrl(url: string): void {
       store.settings.xudDockerUrl = url;
+    },
+    get connectionType(): ConnectionType | undefined {
+      return store.settings.connectionType;
+    },
+    setConnectionType(value: ConnectionType): void {
+      store.settings.connectionType = value;
     },
   });
 


### PR DESCRIPTION
Needed by https://github.com/ExchangeUnion/xud-ui-dashboard/pull/25

Currently, it makes sense to be tested only on Windows until the other platforms also migrate to the launcher and use the landing page (the local connection is not detected otherwise).

What / how to test:
* use `feat/settings` branch for the xud-ui-dashboard
* go to` settings` -> `backup`
* when the remote connection was chosen on the landing page, there should be an input field for the backup directory
* in case the `Start / Create` was chosen on the landing page, a `Choose` button should be displayed and when clicked on that, a dialog for selecting a directory should appear. When a folder is selected, its path should appear to the screen.

All other functionality, and the conditions of displaying other elements are not in the scope of this PR.

In case a url of a local environment is inserted in the `Connect to remote` page, it is still considered as a remote connection as there is no easy and reliable way to determine that it's a local connection.