### PR TITLE
fix: show connection failed error even when url is in bad/illegal format

### DIFF
--- a/src/setup/ConnectToRemote.tsx
+++ b/src/setup/ConnectToRemote.tsx
@@ -135,15 +135,16 @@ const ConnectToRemote = inject(SETTINGS_STORE)(
                       color="primary"
                       disabled={connecting}
                       disableElevation
-                      onClick={() =>
+                      onClick={(e) => {
+                        e.preventDefault();
                         handleConnectClick(
                           setConnectionFailed,
                           setConnecting,
                           history,
                           ipAndPort,
                           settingsStore!.setXudDockerUrl
-                        )
-                      }
+                        );
+                      }}
                     >
                       {connectionFailed ? "Retry" : "Connect"}
                     </Button>


### PR DESCRIPTION
Closes #117
When fetch was used on url with bad/illegal format it caused full page refresh, which led to blank screen in production and error not being shown in development mode.   